### PR TITLE
Add Next.js wasm demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,5 +175,6 @@ Please see our [wiki](https://github.com/snakers4/silero-models/wiki) for releva
 
 - Voice activity detection for the [browser](https://github.com/ricky0123/vad) using ONNX Runtime Web
 - Example React integration in [examples/react-example](https://github.com/snakers4/silero-vad/tree/master/examples/react-example)
+- Example Next.js integration with WebAssembly and AudioWorklet in [examples/nextjs-wasm-silero-vad](https://github.com/snakers4/silero-vad/tree/master/examples/nextjs-wasm-silero-vad)
 
 - [Rust](https://github.com/snakers4/silero-vad/tree/master/examples/rust-example), [Go](https://github.com/snakers4/silero-vad/tree/master/examples/go), [Java](https://github.com/snakers4/silero-vad/tree/master/examples/java-example), [C++](https://github.com/snakers4/silero-vad/tree/master/examples/cpp), [C#](https://github.com/snakers4/silero-vad/tree/master/examples/csharp) and [other](https://github.com/snakers4/silero-vad/tree/master/examples) community examples

--- a/examples/nextjs-wasm-silero-vad/README.md
+++ b/examples/nextjs-wasm-silero-vad/README.md
@@ -1,0 +1,22 @@
+# Next.js + WebAssembly で silero-vad を使うサンプル
+
+このディレクトリでは、Next.js と `onnxruntime-web` を利用してブラウザで silero-vad を実行する例を示します。マイク入力は非推奨となった ScriptProcessorNode ではなく、AudioWorklet で取得します。
+
+## セットアップ手順
+
+1. Node.js (v16 以上) をインストールします。
+2. このディレクトリで依存関係をインストールします。
+   ```bash
+   npm install
+   ```
+3. `src/silero_vad/data/silero_vad.onnx` を `public/` にコピーします。
+   ```bash
+   cp ../../src/silero_vad/data/silero_vad.onnx public/
+   ```
+4. 開発サーバを起動します。
+   ```bash
+   npm run dev
+   ```
+5. ブラウザで `http://localhost:3000` を開き、マイク入力に対して VAD が動作するか確認します。
+
+`public/vad-worklet.js` で AudioWorkletProcessor を定義し、`pages/index.js` から `onnxruntime-web` を用いて推論を実行します。音声は 16kHz モノラルで処理されます。

--- a/examples/nextjs-wasm-silero-vad/package.json
+++ b/examples/nextjs-wasm-silero-vad/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nextjs-wasm-silero-vad",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "onnxruntime-web": "^1.17.0"
+  }
+}

--- a/examples/nextjs-wasm-silero-vad/pages/index.js
+++ b/examples/nextjs-wasm-silero-vad/pages/index.js
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+import * as ort from 'onnxruntime-web';
+
+export default function Home() {
+  const [ready, setReady] = useState(false);
+  const [speech, setSpeech] = useState(false);
+  const sessionRef = useRef(null);
+  const stateRef = useRef(null);
+
+  useEffect(() => {
+    async function init() {
+      sessionRef.current = await ort.InferenceSession.create('/silero_vad.onnx');
+      stateRef.current = new ort.Tensor('float32', new Float32Array(2 * 1 * 128), [2, 1, 128]);
+      await setupWorklet();
+      setReady(true);
+    }
+    init();
+  }, []);
+
+  async function setupWorklet() {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const audioContext = new AudioContext({ sampleRate: 16000 });
+    await audioContext.audioWorklet.addModule('/vad-worklet.js');
+    const source = audioContext.createMediaStreamSource(stream);
+    const workletNode = new AudioWorkletNode(audioContext, 'vad-worklet');
+    workletNode.port.onmessage = (e) => process(e.data);
+    source.connect(workletNode);
+    workletNode.connect(audioContext.destination);
+  }
+
+  async function process(audio) {
+    if (!sessionRef.current || !stateRef.current) return;
+    const input = new ort.Tensor('float32', audio, [1, audio.length]);
+    const sr = new ort.Tensor('int64', new BigInt64Array([16000n]), [1]);
+    const feeds = { input, state: stateRef.current, sr };
+    const results = await sessionRef.current.run(feeds);
+    stateRef.current = results.stateN;
+    setSpeech(results.output.data[0] > 0.5);
+  }
+
+  return (
+    <main>
+      <h1>Silero VAD Next.js Demo</h1>
+      {ready ? <p>{speech ? 'Speech' : 'Silence'}</p> : <p>Loading...</p>}
+    </main>
+  );
+}

--- a/examples/nextjs-wasm-silero-vad/public/vad-worklet.js
+++ b/examples/nextjs-wasm-silero-vad/public/vad-worklet.js
@@ -1,0 +1,11 @@
+class VadWorkletProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0][0];
+    if (input) {
+      this.port.postMessage(new Float32Array(input));
+    }
+    return true;
+  }
+}
+
+registerProcessor('vad-worklet', VadWorkletProcessor);

--- a/examples/rust-example/README.md
+++ b/examples/rust-example/README.md
@@ -17,3 +17,22 @@ If you need to test against other wav file, not `recorder.wav`, specify it as th
 ```
 cargo run -- /path/to/audio/file.wav
 ```
+
+## WebAssembly 対応
+
+ブラウザ上でこの Rust サンプルを動かす際の基本手順です。
+
+1. **ターゲットの追加**
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
+2. **`ort` クレートの設定**
+   `Cargo.toml` の依存を `wasm-bindgen` 用の機能に変更します（例：`features = ["wasm-bindgen", "ndarray"]`）。
+3. **ビルド**
+   ```bash
+   cargo build --release --target wasm32-unknown-unknown
+   ```
+4. **ブラウザから実行**
+   生成された `.wasm` と JavaScript ラッパーをサーバー上に配置し、`silero_vad.onnx` を同じ場所から取得できるようにします。
+
+`ort` の wasm サポートはバージョンによって変わる場合があります。詳細はクレートのドキュメントをご確認ください。


### PR DESCRIPTION
## Summary
- add a Next.js example using onnxruntime-web with AudioWorklet
- document setup instructions in Japanese
- mention the new demo in the main README

## Testing
- `git status --short`