### PR TITLE
Add SharedArrayBuffer support to Next.js example

### DIFF
--- a/examples/nextjs-wasm-silero-vad/README.md
+++ b/examples/nextjs-wasm-silero-vad/README.md
@@ -9,20 +9,23 @@
    ```bash
    npm install
    ```
-3. `src/silero_vad/data/silero_vad.onnx` を `public/` にコピーします。
+3. `next.config.js` では Cross-Origin Opener Policy と Cross-Origin Embedder Policy のヘッダーを付与しています。開発サーバを起動するだけで `SharedArrayBuffer` が利用可能になります。
+4. `src/silero_vad/data/silero_vad.onnx` を `public/` にコピーします。
    ```bash
    cp ../../src/silero_vad/data/silero_vad.onnx public/
    ```
-4. 任意で DeepFilterNet3 のモデル `deepfilternet.onnx` を `public/` に配置します。
-5. `node_modules/onnxruntime-web/dist/ort.min.js` を `public/` にコピーします。
-6. 開発サーバを起動します。
+5. 任意で DeepFilterNet3 のモデル `deepfilternet.onnx` を `public/` に配置します。
+6. `node_modules/onnxruntime-web/dist/ort.min.js` を `public/` にコピーします。
+7. 開発サーバを起動します。
    ```bash
    npm run dev
    ```
-7. ブラウザで `http://localhost:3000` を開き、マイク入力に対して VAD が動作するか確認します。
+8. ブラウザで `http://localhost:3000` を開き、マイク入力に対して VAD が動作するか確認します。
    `http://localhost:3000/denoise` では DeepFilterNet3 を用いたデノイズ処理のデモが実行されます（モデルと `ort.min.js` が存在する場合）。
 
 `public/vad-worklet.js` と `public/denoise-worklet.js` で AudioWorkletProcessor を定義します。VAD ではメインスレッドから `onnxruntime-web` を用いて推論を実行し、デノイズでは `denoise-worker.js` が推論を担当します。音声は VAD では 16kHz、デノイズでは 48kHz モノラルで処理されます。
 
 VAD モデルは 512 サンプルのフレームと 64 サンプルのコンテキストを入力として受け取ります。本サンプルでは AudioWorklet から渡されるデータをバッファに保持し、長さ `576` のテンソルを作成してから推論を行います。
+
+バージョンアップに伴い、デノイズ処理では `SharedArrayBuffer` を利用したワーカー通信に対応しました。`next.config.js` で Cross-Origin Opener Policy と Cross-Origin Embedder Policy のヘッダーを付与しているため、開発サーバをそのまま起動すれば共有メモリを用いた高速な処理を試すことができます。
 

--- a/examples/nextjs-wasm-silero-vad/next.config.js
+++ b/examples/nextjs-wasm-silero-vad/next.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
+        ],
+      },
+    ];
+  },
+};

--- a/examples/nextjs-wasm-silero-vad/pages/_document.js
+++ b/examples/nextjs-wasm-silero-vad/pages/_document.js
@@ -1,0 +1,16 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <meta httpEquiv="Cross-Origin-Opener-Policy" content="same-origin" />
+        <meta httpEquiv="Cross-Origin-Embedder-Policy" content="require-corp" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/examples/nextjs-wasm-silero-vad/pages/denoise.js
+++ b/examples/nextjs-wasm-silero-vad/pages/denoise.js
@@ -4,28 +4,43 @@ export default function Denoise() {
   const [ready, setReady] = useState(false);
   const workerRef = useRef(null);
   const nodeRef = useRef(null);
+  const sabInRef = useRef(null);
+  const sabOutRef = useRef(null);
 
   useEffect(() => {
     async function init() {
+      sabInRef.current = new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 480);
+      sabOutRef.current = new SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * 480);
+
       workerRef.current = new Worker('/denoise-worker.js');
       workerRef.current.onmessage = (e) => {
         if (e.data.type === 'ready') {
           setReady(true);
-        } else if (e.data.type === 'output') {
-          nodeRef.current.port.postMessage({ type: 'output', audio: e.data.audio }, [e.data.audio.buffer]);
+        } else if (e.data.type === 'outputReady') {
+          nodeRef.current.port.postMessage({ type: 'outputReady' });
         }
       };
-      workerRef.current.postMessage({ type: 'init', modelUrl: '/deepfilternet.onnx' });
+      workerRef.current.postMessage({
+        type: 'init',
+        modelUrl: '/deepfilternet.onnx',
+        sabIn: sabInRef.current,
+        sabOut: sabOutRef.current,
+      }, [sabInRef.current, sabOutRef.current]);
 
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const audioContext = new AudioContext({ sampleRate: 48000 });
       await audioContext.audioWorklet.addModule('/denoise-worklet.js');
       const source = audioContext.createMediaStreamSource(stream);
-      const workletNode = new AudioWorkletNode(audioContext, 'denoise-worklet');
+      const workletNode = new AudioWorkletNode(audioContext, 'denoise-worklet', {
+        processorOptions: {
+          sabIn: sabInRef.current,
+          sabOut: sabOutRef.current,
+        },
+      });
       nodeRef.current = workletNode;
       workletNode.port.onmessage = (e) => {
         if (e.data.type === 'input') {
-          workerRef.current.postMessage({ type: 'process', audio: e.data.audio }, [e.data.audio.buffer]);
+          workerRef.current.postMessage({ type: 'process' });
         }
       };
       source.connect(workletNode);

--- a/examples/nextjs-wasm-silero-vad/public/denoise-worklet.js
+++ b/examples/nextjs-wasm-silero-vad/public/denoise-worklet.js
@@ -1,10 +1,13 @@
 class DenoiseWorkletProcessor extends AudioWorkletProcessor {
-  constructor() {
+  constructor(options) {
     super();
+    const { sabIn, sabOut } = options.processorOptions || {};
+    this.inputBuf = sabIn ? new Float32Array(sabIn) : null;
+    this.outputBuf = sabOut ? new Float32Array(sabOut) : null;
     this.outQueue = [];
     this.port.onmessage = (e) => {
-      if (e.data.type === 'output') {
-        this.outQueue.push(new Float32Array(e.data.audio));
+      if (e.data.type === 'outputReady' && this.outputBuf) {
+        this.outQueue.push(this.outputBuf.slice(0));
       }
     };
   }
@@ -13,7 +16,12 @@ class DenoiseWorkletProcessor extends AudioWorkletProcessor {
     const input = inputs[0][0];
     const output = outputs[0][0];
     if (input) {
-      this.port.postMessage({ type: 'input', audio: new Float32Array(input) }, [input.buffer]);
+      if (this.inputBuf) {
+        this.inputBuf.set(input);
+        this.port.postMessage({ type: 'input' });
+      } else {
+        this.port.postMessage({ type: 'input', audio: new Float32Array(input) }, [input.buffer]);
+      }
     }
     if (this.outQueue.length > 0) {
       const data = this.outQueue.shift();


### PR DESCRIPTION
## Summary
- support cross-origin isolation with next.config.js and custom Document
- use SharedArrayBuffer for audio transfer in denoise demo
- update README with new setup instructions

## Testing
- `node --check examples/nextjs-wasm-silero-vad/public/denoise-worker.js`
- `node --check examples/nextjs-wasm-silero-vad/public/denoise-worklet.js`
- `node --check examples/nextjs-wasm-silero-vad/pages/denoise.js`
- `node --check examples/nextjs-wasm-silero-vad/pages/_document.js`
- `node --check examples/nextjs-wasm-silero-vad/next.config.js`
